### PR TITLE
Automatically run evolutions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,5 @@ COPY . $PROJECT_HOME/app
 WORKDIR $PROJECT_HOME/app
 EXPOSE 9000
 
-RUN sbt compile -v
-CMD ["sbt", "--version"]
-
+RUN sbt -v clean compile stage
+CMD ["./target/universal/stage/bin/smsalertsystemv2", "-Dplay.evolutions.db.default.autoApply=true", "-Dplay.http.secret.key=$PLAY_SECRET_KEY"]

--- a/README.md
+++ b/README.md
@@ -45,10 +45,28 @@ export TWILIO_USERNAME="..."
 export TWILIO_PASSWORD="..."
 # the phone number you created
 export TWILIO_PHONE="..."
-sbt run
+sbt clean compile stage
+./target/universal/stage/bin/smsalertsystemv2 \
+  -Dplay.evolutions.db.default.autoApply=true \
+	-Dplay.http.secret.key=l33t_52uc3
 ```
 
 This will launch a local version of the application with in memory database. The first time you load the page you will be asked to update the database schema but then it should be functional.
+
+## Runnning Via Docker
+
+The project is deployed to AWS ECS, which runs the docker image built from the `Dockerfile` defined in this project. You
+can build and run the docker container via:
+```
+docker build .
+docker run \
+   -e "TWILIO_USERNAME=username" \
+   -e "TWILIO_PASSWORD=password" \
+   -e "TWILIO_PHONE=+10000000000" \
+   -e "PLAY_SECRET_KEY=l33t_52uc3" \
+   -p 9000:9000 2cb4c70f20cb
+wget localhost:9000
+```
 
 # Deploying to the Cloud
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,23 @@
 name := "SmsAlertSystemV2"
- 
-version := "1.0" 
-      
-lazy val `smsalertsystemv2` = (project in file(".")).enablePlugins(PlayScala)
-
-resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
-      
-resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
-      
+version := "1.0"
 scalaVersion := "2.12.2"
 
+lazy val `smsalertsystemv2` = (project in file(".")).enablePlugins(PlayScala)
+
+resolvers ++= Seq(
+  "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
+  "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
+)
+      
 libraryDependencies ++= Seq(
   ehcache,
   ws,
-  specs2 % Test,
   guice,
   "com.twilio.sdk" % "twilio" % "7.15.0",
   "com.typesafe.play" %% "play-slick" %  "3.0.2",
   "com.typesafe.play" %% "play-slick-evolutions" % "3.0.2",
   "com.h2database" % "h2" % "1.4.194",
+  specs2 % Test,
   "com.typesafe.akka" %% "akka-testkit" % "2.5.4" % "test",
   "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 )      

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -323,7 +323,7 @@ play.filters {
 #
 play.evolutions {
   # You can disable evolutions for a specific datasource if necessary
-  #db.default.enabled = false
+  db.default.enabled = true
 }
 
 ## Database Connection Pool


### PR DESCRIPTION
[Problem]
During deployment to ECS, the task will automatically get restarted by the ECS service if the ELB determines that the
service is unhealthy. Currently the project is configured to require the user to run evolutions through the UI rather
than automatically running them, which is causing the service to fail on ECS.

[Solution]
Automatically run evolutions at start up.

[Test]
Created docker image, instantiated container, and ran wget request:
$ docker run \
   -e "TWILIO_USERNAME=username" \
   -e "TWILIO_PASSWORD=password" \
   -e "TWILIO_PHONE=+10000000000" \
   -e "PLAY_SECRET_KEY=benjamyn" \
   -p 9000:9000 2cb4c70f20cb
$ wget localhost:9000

Ran local instructions:
$ sbt clean compile stage
$ ./target/universal/stage/bin/smsalertsystemv2 \
   -Dplay.evolutions.db.default.autoApply=true \
   -Dplay.http.secret.key=l33t_52uc3