### PR TITLE
Issue-31: Allow Elastic Load Balancer to perform health checks

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -307,7 +307,7 @@ play.filters {
   # Play provides a filter that lets you configure which hosts can access your application.
   # This is useful to prevent cache poisoning attacks.
   hosts {
-    allowed = [".ngrok.io", "localhost:9000", "127.0.0.1:9000"]
+    allowed = ["localhost:9000", "127.0.0.1:9000", "."]
     # Allow requests to example.com, its subdomains, and localhost:9000.
     #allowed = [".example.com", "localhost:9000"]
   }


### PR DESCRIPTION
[Problem]
The play.filters.hosts.allowed does not permit requests arriving from outside the local host. This causes all requests
hitting port 9000 to fail.

[Solution]
Permit outside hosts to hit port 9000 as well as dynamic ports. Limiting to just port 9000 causes requests through the
ELB to fail with:
```
Bad Request
For request 'GET /' [Host not allowed: alertsysloadbalancergamma-2103416884.us-west-2.elb.amazonaws.com]
```

[Test]
* Tested locally:
   * Verified without change that `curl -v http://192.168.1.100:9000/` does not work
   * Works running outside docker with change
   * Works running inside docker with change
* Built docker image and deployed to ECS cluster and works - verified on ECS instance that the new image was being used